### PR TITLE
Make golint happy. Change StDev to StdDev.

### DIFF
--- a/stat.go
+++ b/stat.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gonum/floats"
 )
 
+// CumulantKind specifies the behavior for calculating the empirical CDF or Quantile
 type CumulantKind int
 
 const (
@@ -68,7 +69,7 @@ func CDF(q float64, c CumulantKind, x, weights []float64) float64 {
 				return w / sumWeights
 			}
 			if weights == nil {
-				w += 1
+				w++
 			} else {
 				w += weights[i]
 			}
@@ -187,7 +188,7 @@ func kurtosisCorrection(n float64) (mul, offset float64) {
 	return ((n + 1) / (n - 1)) * (n / (n - 2)) * (1 / (n - 3)), 3 * ((n - 1) / (n - 2)) * ((n - 1) / (n - 3))
 }
 
-// GeoMean returns the weighted geometric mean of the dataset
+// GeometricMean returns the weighted geometric mean of the dataset
 //  \prod_i {x_i ^ w_i}
 // This only applies with positive x and positive weights. If weights is nil
 // then all of the weights are 1. If weights is not nil, then len(x) must equal
@@ -216,7 +217,7 @@ func GeometricMean(x, weights []float64) float64 {
 	return math.Exp(s)
 }
 
-// GeoMean returns the weighted harmonic mean of the dataset
+// HarmonicMean returns the weighted harmonic mean of the dataset
 //  \sum_i {w_i} / ( sum_i {w_i / x_i} )
 // This only applies with positive x and positive weights.
 // If weights is nil then all of the weights are 1. If weights is not nil, then
@@ -236,7 +237,7 @@ func HarmonicMean(x, weights []float64) float64 {
 	for i := range x {
 		if weights == nil {
 			logs[i] = -math.Log(x[i])
-			W += 1
+			W++
 			continue
 		}
 		logs[i] = math.Log(weights[i]) - math.Log(x[i])
@@ -282,7 +283,7 @@ func Histogram(count, dividers, x, weights []float64) []float64 {
 		for _, v := range x {
 			if v < comp || idx == len(count)-1 {
 				// Still in the current bucket
-				count[idx] += 1
+				count[idx]++
 				continue
 			}
 			// Need to find the next divider where v is less than the divider
@@ -298,7 +299,7 @@ func Histogram(count, dividers, x, weights []float64) []float64 {
 					break
 				}
 			}
-			count[idx] += 1
+			count[idx]++
 		}
 		return count
 	}
@@ -380,7 +381,7 @@ func Mode(x []float64, weights []float64) (val float64, count float64) {
 	m := make(map[float64]float64)
 	if weights == nil {
 		for _, v := range x {
-			m[v] += 1
+			m[v]++
 		}
 	} else {
 		for i, v := range x {
@@ -466,7 +467,7 @@ func Quantile(p float64, c CumulantKind, x, weights []float64) float64 {
 		fidx := p * sumWeights
 		for i := range x {
 			if weights == nil {
-				cumsum += 1
+				cumsum++
 			} else {
 				cumsum += weights[i]
 			}
@@ -549,11 +550,11 @@ func (w weightSorter) Len() int {
 }
 
 // StdDev returns the population standard deviation with the provided mean.
-func StDev(x []float64, mean float64, weights []float64) float64 {
+func StdDev(x []float64, mean float64, weights []float64) float64 {
 	return math.Sqrt(Variance(x, mean, weights))
 }
 
-// StandardError returns the standard error in the mean with the given values.
+// StdErr returns the standard error in the mean with the given values.
 func StdErr(stdev, sampleSize float64) float64 {
 	return stdev / math.Sqrt(sampleSize)
 }

--- a/stat_test.go
+++ b/stat_test.go
@@ -25,8 +25,8 @@ func ExampleCorrelation() {
 	meanY := Mean(x, w)
 	c := Correlation(x, meanX, 3, y, meanY, 4, w)
 	fmt.Printf("Correlation with set standard deviatons is %.5f\n", c)
-	stdX := StDev(x, meanX, w)
-	stdY := StDev(x, meanY, w)
+	stdX := StdDev(x, meanX, w)
+	stdY := StdDev(x, meanY, w)
 	c2 := Correlation(x, meanX, stdX, y, meanY, stdY, w)
 	fmt.Printf("Correlation with computed standard deviatons is %.5f\n", c2)
 	// Output:
@@ -84,8 +84,8 @@ func TestCorrelation(t *testing.T) {
 	} {
 		meanX := Mean(test.x, test.w)
 		meanY := Mean(test.y, test.w)
-		stdX := StDev(test.x, meanX, test.w)
-		stdY := StDev(test.y, meanY, test.w)
+		stdX := StdDev(test.x, meanX, test.w)
+		stdY := StdDev(test.y, meanY, test.w)
 		c := Correlation(test.x, meanX, stdX, test.y, meanY, stdY, test.w)
 		if math.Abs(test.ans-c) > 1e-14 {
 			t.Errorf("Correlation mismatch case %d. Expected %v, Found %v", i, test.ans, c)
@@ -185,12 +185,12 @@ excess kurtosis is the kurtosis above or below that of the standard normal
 distribution`)
 	x := []float64{5, 4, -3, -2}
 	mean := Mean(x, nil)
-	stdev := StDev(x, mean, nil)
+	stdev := StdDev(x, mean, nil)
 	kurt := ExKurtosis(x, mean, stdev, nil)
 	fmt.Printf("ExKurtosis = %.5f\n", kurt)
 	weights := []float64{1, 2, 3, 5}
 	wMean := Mean(x, weights)
-	wStdev := StDev(x, wMean, weights)
+	wStdev := StdDev(x, wMean, weights)
 	wKurt := ExKurtosis(x, wMean, wStdev, weights)
 	fmt.Printf("Weighted ExKurtosis is %.4f", wKurt)
 	// Output:
@@ -506,15 +506,15 @@ func TestQuantile(t *testing.T) {
 	}
 }
 
-func ExampleStDev() {
+func ExampleStdDev() {
 	x := []float64{8, 2, -9, 15, 4}
 	mean := Mean(x, nil)
-	stdev := StDev(x, mean, nil)
+	stdev := StdDev(x, mean, nil)
 	fmt.Printf("The standard deviation of the samples is %.4f\n", stdev)
 
 	weights := []float64{2, 2, 6, 7, 1}
 	weightedMean := Mean(x, weights)
-	weightedStdev := StDev(x, weightedMean, weights)
+	weightedStdev := StdDev(x, weightedMean, weights)
 	fmt.Printf("The weighted standard deviation of the samples is %.4f\n", weightedStdev)
 	// Output:
 	// The standard deviation of the samples is 8.8034
@@ -525,7 +525,7 @@ func ExampleStdErr() {
 	x := []float64{8, 2, -9, 15, 4}
 	weights := []float64{2, 2, 6, 7, 1}
 	mean := Mean(x, weights)
-	stdev := StDev(x, mean, weights)
+	stdev := StdDev(x, mean, weights)
 	nSamples := floats.Sum(weights)
 	stdErr := StdErr(stdev, nSamples)
 	fmt.Printf("The standard deviation is %.4f and there are %g samples, so the mean\nis likely %.4f ± %.4f.", stdev, nSamples, mean, stdErr)
@@ -557,7 +557,7 @@ func TestSkew(t *testing.T) {
 		},
 	} {
 		mean := Mean(test.x, test.weights)
-		std := StDev(test.x, mean, test.weights)
+		std := StdDev(test.x, mean, test.weights)
 		skew := Skew(test.x, mean, std, test.weights)
 		if math.Abs(skew-test.ans) > 1e-14 {
 			t.Errorf("Skew mismatch case %d. Expected %v, Found %v", i, test.ans, skew)


### PR DESCRIPTION
This CL changes the function signature from StDev to StdDev to match the other StandardXxx functions.
Additionally, this PR fixes the comments that don't start with the correct name
and changes +=1 to ++ by recommendation from golint
