### PR TITLE
Only perform cover when gonum branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
  - go build -v ./...
  - go test -v ./...
  - diff <(gofmt -d .) <("")
- - bash test-coverage.sh
+ - if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then bash test-coverage.sh; fi
 
 after_failure: failure
 


### PR DESCRIPTION
Travis only allows secure environment variables to be decoded when
merging a branch.  This change only performs coveralls when that api
key is available.
