### PR TITLE
Make Marshaler internal and rename

### DIFF
--- a/dist/exponential.go
+++ b/dist/exponential.go
@@ -123,17 +123,6 @@ func (e Exponential) LogProb(x float64) float64 {
 	return math.Log(e.Rate) - e.Rate*x
 }
 
-// MarshalParameters implements the ParameterMarshaler interface
-func (e Exponential) MarshalParameters(p []Parameter) {
-	nParam := e.NumParameters()
-	if len(p) != nParam {
-		panic("exponential: improper parameter length")
-	}
-	p[0].Name = "Rate"
-	p[0].Value = e.Rate
-	return
-}
-
 // Mean returns the mean of the probability distribution.
 func (e Exponential) Mean() float64 {
 	return 1 / e.Rate
@@ -229,8 +218,8 @@ func (e Exponential) Survival(x float64) float64 {
 	return math.Exp(-e.Rate * x)
 }
 
-// UnmarshalParameters implements the ParameterMarshaler interface
-func (e *Exponential) UnmarshalParameters(p []Parameter) {
+// setParameters modifies the parameters of the distribution.
+func (e *Exponential) setParameters(p []Parameter) {
 	if len(p) != e.NumParameters() {
 		panic("exponential: incorrect number of parameters to set")
 	}
@@ -243,4 +232,17 @@ func (e *Exponential) UnmarshalParameters(p []Parameter) {
 // Variance returns the variance of the probability distribution.
 func (e Exponential) Variance() float64 {
 	return 1 / (e.Rate * e.Rate)
+}
+
+// parameters returns the parameters of the distribution.
+func (e Exponential) parameters(p []Parameter) []Parameter {
+	nParam := e.NumParameters()
+	if p == nil {
+		p = make([]Parameter, nParam)
+	} else if len(p) != nParam {
+		panic("exponential: improper parameter length")
+	}
+	p[0].Name = "Rate"
+	p[0].Value = e.Rate
+	return p
 }

--- a/dist/exponential_test.go
+++ b/dist/exponential_test.go
@@ -40,8 +40,5 @@ func TestExponentialProb(t *testing.T) {
 }
 
 func TestExponentialFitPrior(t *testing.T) {
-	testConjugateUpdate(t, &Exponential{
-		Rate: 13.7,
-	},
-		func() ConjugateUpdater { return &Exponential{} })
+	testConjugateUpdate(t, func() ConjugateUpdater { return &Exponential{Rate: 13.7} })
 }

--- a/dist/general.go
+++ b/dist/general.go
@@ -5,21 +5,3 @@ type Parameter struct {
 	Name  string
 	Value float64
 }
-
-// A ParameterMarshaler is a type that can marshal itself into a slice of Paramaters
-// and unmarshal itself from the slice of parameters.
-// ParameterMarshaler exists to support algorithms that modify parameters of arbitrary distributions.
-// Typically, users should modify distributions using the fields of the specifc
-// distribution.
-// Marshal and Unmarshal are to be used as a pair, users should not attempt to construct
-// the Parameter slice themselves.
-//
-// Both MarshalParameters and  UnmarshalParameters will
-// panic if the length of the slice is not equal to the number of parameters.
-// UnmarshalParameters will panic if the names of the parameters do not match.
-// UnmarshalParameters tests names in the same order as they were created in
-// MarshalParameters.
-type ParameterMarshaler interface {
-	MarshalParameters([]Parameter)
-	UnmarshalParameters([]Parameter)
-}

--- a/dist/norm.go
+++ b/dist/norm.go
@@ -111,19 +111,6 @@ func (n Normal) LogProb(x float64) float64 {
 	return negLogRoot2Pi - math.Log(n.Sigma) - (x-n.Mu)*(x-n.Mu)/(2*n.Sigma*n.Sigma)
 }
 
-// MarshalParameters implements the ParameterMarshaler interface
-func (n Normal) MarshalParameters(p []Parameter) {
-	nParam := n.NumParameters()
-	if len(p) != nParam {
-		panic("normal: improper parameter length")
-	}
-	p[0].Name = "Mu"
-	p[0].Value = n.Mu
-	p[1].Name = "Sigma"
-	p[1].Value = n.Sigma
-	return
-}
-
 // Mean returns the mean of the probability distribution.
 func (n Normal) Mean() float64 {
 	return n.Mu
@@ -220,8 +207,8 @@ func (n Normal) Survival(x float64) float64 {
 	return 0.5 * (1 - math.Erf((x-n.Mu)/(n.Sigma*math.Sqrt2)))
 }
 
-// UnmarshalParameters implements the ParameterMarshaler interface
-func (n *Normal) UnmarshalParameters(p []Parameter) {
+// setParameters modifies the parameters of the distribution.
+func (n *Normal) setParameters(p []Parameter) {
 	if len(p) != n.NumParameters() {
 		panic("normal: incorrect number of parameters to set")
 	}
@@ -346,4 +333,19 @@ func zQuantile(p float64) float64 {
 		return -x
 	}
 	return x
+}
+
+// parameters returns the parameters of the distribution.
+func (n Normal) parameters(p []Parameter) []Parameter {
+	nParam := n.NumParameters()
+	if p == nil {
+		p = make([]Parameter, nParam)
+	} else if len(p) != nParam {
+		panic("normal: improper parameter length")
+	}
+	p[0].Name = "Mu"
+	p[0].Value = n.Mu
+	p[1].Name = "Sigma"
+	p[1].Value = n.Sigma
+	return p
 }

--- a/dist/norm_test.go
+++ b/dist/norm_test.go
@@ -81,9 +81,5 @@ func TestNormalProbs(t *testing.T) {
 }
 
 func TestNormFitPrior(t *testing.T) {
-	testConjugateUpdate(t, &Normal{
-		Mu:    -10,
-		Sigma: 6,
-	},
-		func() ConjugateUpdater { return &Normal{} })
+	testConjugateUpdate(t, func() ConjugateUpdater { return &Normal{Mu: -10, Sigma: 6} })
 }

--- a/dist/weibull.go
+++ b/dist/weibull.go
@@ -122,19 +122,6 @@ func (w Weibull) LogSurvival(x float64) float64 {
 	}
 }
 
-// MarshalParameters implements the ParameterMarshaler interface.
-func (w Weibull) MarshalParameters(p []Parameter) {
-	nParam := w.NumParameters()
-	if len(p) != nParam {
-		panic("weibull: improper parameter length")
-	}
-	p[0].Name = "K"
-	p[0].Value = w.K
-	p[1].Name = "λ"
-	p[1].Value = w.Lambda
-	return
-}
-
 // Mean returns the mean of the probability distribution.
 func (w Weibull) Mean() float64 {
 	return w.Lambda * math.Gamma(1+1/w.K)
@@ -212,10 +199,10 @@ func (w Weibull) Survival(x float64) float64 {
 	return math.Exp(w.LogSurvival(x))
 }
 
-// UnmarshalParameters implements the ParameterMarshaler interface.
-func (w *Weibull) UnmarshalParameters(p []Parameter) {
+// setParameters modifies the parameters of the distribution.
+func (w *Weibull) setParameters(p []Parameter) {
 	if len(p) != w.NumParameters() {
-		panic("weibull: incorrect number of parameters to set")
+		panic("normal: incorrect number of parameters to set")
 	}
 	if p[0].Name != "K" {
 		panic("weibull: " + panicNameMismatch)
@@ -230,4 +217,20 @@ func (w *Weibull) UnmarshalParameters(p []Parameter) {
 // Variance returns the variance of the probability distribution.
 func (w Weibull) Variance() float64 {
 	return math.Pow(w.Lambda, 2) * (math.Gamma(1+2/w.K) - w.gammaIPow(1, 2))
+}
+
+// parameters returns the parameters of the distribution.
+func (w Weibull) parameters(p []Parameter) []Parameter {
+	nParam := w.NumParameters()
+	if p == nil {
+		p = make([]Parameter, nParam)
+	} else if len(p) != nParam {
+		panic("weibull: improper parameter length")
+	}
+	p[0].Name = "K"
+	p[0].Value = w.K
+	p[1].Name = "λ"
+	p[1].Value = w.Lambda
+	return p
+
 }


### PR DESCRIPTION
I’ve changed `MarshalParamers` and `UnmarshalParameters` to
`getParameters` and `setParameters`, respectively.  I’ve also modified
the testConjugateUpdate function to be a table driven test, and perform
more comparisons.  It turns out that by modifying its signature, it
wasn’t necessary to use the new `parameterMutator` interface, although
that will still be useful for other serialization.

I implemented `setParameters` and `getParameters` as discussed
previously, but it would also be possible to write a single 
`Parameters([]Parameter) []Parameter` which would act as both set and
get in the same manner as `runtime.GOMAXPROCS`.

This follows up #31, PTAL @btracey, @kortschak 
