### PR TITLE
stat: avoid overloaded word

### DIFF
--- a/covariancematrix_test.go
+++ b/covariancematrix_test.go
@@ -61,7 +61,7 @@ func TestCovarianceMatrix(t *testing.T) {
 			copy(w, test.weights)
 		}
 		c := CovarianceMatrix(nil, test.data, test.weights)
-		if !c.Equals(test.ans) {
+		if !mat64.Equal(c, test.ans) {
 			t.Errorf("%d: expected cov %v, found %v", i, test.ans, c)
 		}
 		if !floats.Equal(d, r.Data) {
@@ -155,7 +155,7 @@ func TestCorrelationMatrix(t *testing.T) {
 			copy(w, test.weights)
 		}
 		c := CorrelationMatrix(nil, test.data, test.weights)
-		if !c.Equals(test.ans) {
+		if !mat64.Equal(c, test.ans) {
 			t.Errorf("%d: expected corr %v, found %v", i, test.ans, c)
 		}
 		if !floats.Equal(d, r.Data) {

--- a/covariancematrix_test.go
+++ b/covariancematrix_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestCovarianceMatrix(t *testing.T) {
-	// An alternate way to test this is to call the Variance
-	// and Covariance functions and ensure that the results are identical.
+	// An alternative way to test this is to call the Variance and
+	// Covariance functions and ensure that the results are identical.
 	for i, test := range []struct {
 		data    *mat64.Dense
 		weights []float64


### PR DESCRIPTION
The word "alternate" is not universally correct English here (correct in North America and some parts of Australian speech). Use the word that is universally unambiguous.

@jonlawlor @btracey Please take a look.