### PR TITLE
Change build status to only report master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gonum Stat  [![Build Status](https://travis-ci.org/gonum/stat.svg)](https://travis-ci.org/gonum/stat)  [![Coverage Status](https://coveralls.io/repos/gonum/stat/badge.svg?branch=master&service=github)](https://coveralls.io/github/gonum/stat?branch=master)
+# Gonum Stat  [![Build Status](https://travis-ci.org/gonum/stat.svg?branch=master)](https://travis-ci.org/gonum/stat)  [![Coverage Status](https://coveralls.io/repos/gonum/stat/badge.svg?branch=master&service=github)](https://coveralls.io/github/gonum/stat?branch=master)
 
 This is a statistics package for the Go language.
 


### PR DESCRIPTION
Failed builds in non-master branches were showing up as failed overall.