### PR TITLE
Fix error messages and improve tests.

### DIFF
--- a/distuv/bernoulli.go
+++ b/distuv/bernoulli.go
@@ -65,11 +65,10 @@ func (b Bernoulli) Mean() float64 {
 // Median returns the median of the probability distribution.
 func (b Bernoulli) Median() float64 {
 	p := b.P
-	q := 1 - p
 	switch {
-	case p < q:
+	case p < 0.5:
 		return 0
-	case p > q:
+	case p > 0.5:
 		return 1
 	default:
 		return 0.5
@@ -88,8 +87,8 @@ func (b Bernoulli) Prob(x float64) float64 {
 
 // Quantile returns the inverse of the cumulative probability distribution.
 func (b Bernoulli) Quantile(p float64) float64 {
-	if p < 0 || p > 1 {
-		panic("dist: percentile out of bounds")
+	if p < 0 || 1 < p {
+		panic(badPercentile)
 	}
 	if p < 1-b.P {
 		return 0

--- a/distuv/exponential.go
+++ b/distuv/exponential.go
@@ -116,7 +116,7 @@ func (e Exponential) Prob(x float64) float64 {
 // Quantile returns the inverse of the cumulative probability distribution.
 func (e Exponential) Quantile(p float64) float64 {
 	if p < 0 || p > 1 {
-		panic("dist: percentile out of bounds")
+		panic(badPercentile)
 	}
 	return -math.Log(1-p) / e.Rate
 }
@@ -151,7 +151,7 @@ func (e Exponential) Score(deriv []float64, x float64) []float64 {
 		deriv = make([]float64, e.NumParameters())
 	}
 	if len(deriv) != e.NumParameters() {
-		panic("dist: slice length mismatch")
+		panic(badLength)
 	}
 	if x > 0 {
 		deriv[0] = 1/e.Rate - x
@@ -202,11 +202,11 @@ func (e Exponential) StdDev() float64 {
 // len(samples) != len(weights). Panics if len(suffStat) != 1.
 func (Exponential) SuffStat(samples, weights, suffStat []float64) (nSamples float64) {
 	if len(weights) != 0 && len(samples) != len(weights) {
-		panic("dist: slice size mismatch")
+		panic(badLength)
 	}
 
 	if len(suffStat) != 1 {
-		panic("exponential: wrong suffStat length")
+		panic(badSuffStat)
 	}
 
 	if len(weights) == 0 {

--- a/distuv/general.go
+++ b/distuv/general.go
@@ -10,3 +10,10 @@ type Parameter struct {
 	Name  string
 	Value float64
 }
+
+var (
+	badPercentile = "distuv: percentile out of bounds"
+	badLength     = "distuv: slice length mismatch"
+	badSuffStat   = "distuv: wrong suffStat length"
+	badNoSamples  = "distuv: must have at least one sample"
+)

--- a/distuv/laplace.go
+++ b/distuv/laplace.go
@@ -47,11 +47,11 @@ func (l Laplace) ExKurtosis() float64 {
 // statistics.
 func (l *Laplace) Fit(samples, weights []float64) {
 	if len(samples) != len(weights) {
-		panic("dist: length of samples and weights must match")
+		panic(badLength)
 	}
 
 	if len(samples) == 0 {
-		panic("dist: must have at least one sample")
+		panic(badNoSamples)
 	}
 	if len(samples) == 1 {
 		l.Mu = samples[0]
@@ -99,7 +99,7 @@ func (l Laplace) LogProb(x float64) float64 {
 // MarshalParameters implements the ParameterMarshaler interface
 func (l Laplace) MarshalParameters(p []Parameter) {
 	if len(p) != l.NumParameters() {
-		panic("dist: slice length mismatch")
+		panic(badLength)
 	}
 	p[0].Name = "Mu"
 	p[0].Value = l.Mu
@@ -131,7 +131,7 @@ func (l Laplace) NumParameters() int {
 // Quantile returns the inverse of the cumulative probability distribution.
 func (l Laplace) Quantile(p float64) float64 {
 	if p < 0 || p > 1 {
-		panic("dist: percentile out of bounds")
+		panic(badPercentile)
 	}
 	if p < 0.5 {
 		return l.Mu + l.Scale*math.Log(1+2*(p-0.5))
@@ -178,7 +178,7 @@ func (l Laplace) Score(deriv []float64, x float64) []float64 {
 		deriv = make([]float64, l.NumParameters())
 	}
 	if len(deriv) != l.NumParameters() {
-		panic("dist: slice length mismatch")
+		panic(badLength)
 	}
 	diff := x - l.Mu
 	if diff > 0 {
@@ -234,7 +234,7 @@ func (l Laplace) Survival(x float64) float64 {
 // UnmarshalParameters implements the ParameterMarshaler interface
 func (l *Laplace) UnmarshalParameters(p []Parameter) {
 	if len(p) != l.NumParameters() {
-		panic("dist: slice length mismatch")
+		panic(badLength)
 	}
 	if p[0].Name != "Mu" {
 		panic("laplace: " + panicNameMismatch)

--- a/distuv/lognormal.go
+++ b/distuv/lognormal.go
@@ -72,7 +72,7 @@ func (l LogNormal) Prob(x float64) float64 {
 // Quantile returns the inverse of the cumulative probability distribution.
 func (l LogNormal) Quantile(p float64) float64 {
 	if p < 0 || p > 1 {
-		panic("dist: percentile out of bounds")
+		panic(badPercentile)
 	}
 	// Formula from http://www.math.uah.edu/stat/special/LogNormal.html.
 	return math.Exp(l.Mu + l.Sigma*UnitNormal.Quantile(p))

--- a/distuv/norm.go
+++ b/distuv/norm.go
@@ -121,7 +121,7 @@ func (n Normal) Prob(x float64) float64 {
 // Quantile returns the inverse of the cumulative probability distribution.
 func (n Normal) Quantile(p float64) float64 {
 	if p < 0 || p > 1 {
-		panic("dist: percentile out of bounds")
+		panic(badPercentile)
 	}
 	return n.Mu + n.Sigma*zQuantile(p)
 }
@@ -153,7 +153,7 @@ func (n Normal) Score(deriv []float64, x float64) []float64 {
 		deriv = make([]float64, n.NumParameters())
 	}
 	if len(deriv) != n.NumParameters() {
-		panic("dist: slice length mismatch")
+		panic(badLength)
 	}
 	deriv[0] = (x - n.Mu) / (n.Sigma * n.Sigma)
 	deriv[1] = 1 / n.Sigma * (-1 + ((x-n.Mu)/n.Sigma)*((x-n.Mu)/n.Sigma))
@@ -190,10 +190,10 @@ func (n Normal) StdDev() float64 {
 func (Normal) SuffStat(samples, weights, suffStat []float64) (nSamples float64) {
 	lenSamp := len(samples)
 	if len(weights) != 0 && len(samples) != len(weights) {
-		panic("dist: slice size mismatch")
+		panic(badLength)
 	}
 	if len(suffStat) != 2 {
-		panic("dist: incorrect suffStat length")
+		panic(badSuffStat)
 	}
 
 	if len(weights) == 0 {

--- a/distuv/uniform.go
+++ b/distuv/uniform.go
@@ -96,7 +96,7 @@ func (u Uniform) Prob(x float64) float64 {
 // Quantile returns the inverse of the cumulative probability distribution.
 func (u Uniform) Quantile(p float64) float64 {
 	if p < 0 || p > 1 {
-		panic("dist: percentile out of bounds")
+		panic(badPercentile)
 	}
 	return p*(u.Max-u.Min) + u.Min
 }

--- a/distuv/weibull.go
+++ b/distuv/weibull.go
@@ -121,7 +121,7 @@ func (w Weibull) Prob(x float64) float64 {
 // Quantile returns the inverse of the cumulative probability distribution.
 func (w Weibull) Quantile(p float64) float64 {
 	if p < 0 || p > 1 {
-		panic("weibull: percentile out of bounds")
+		panic(badPercentile)
 	}
 	return w.Lambda * math.Pow(-math.Log(1-p), 1/w.K)
 }
@@ -156,7 +156,7 @@ func (w Weibull) Score(deriv []float64, x float64) []float64 {
 		deriv = make([]float64, w.NumParameters())
 	}
 	if len(deriv) != w.NumParameters() {
-		panic("weibull: slice length mismatch")
+		panic(badLength)
 	}
 	if x > 0 {
 		deriv[0] = 1/w.K + math.Log(x) - math.Log(w.Lambda) - (math.Log(x)-math.Log(w.Lambda))*math.Pow(x/w.Lambda, w.K)
@@ -213,7 +213,7 @@ func (w Weibull) Survival(x float64) float64 {
 // setParameters modifies the parameters of the distribution.
 func (w *Weibull) setParameters(p []Parameter) {
 	if len(p) != w.NumParameters() {
-		panic("normal: incorrect number of parameters to set")
+		panic("weibull: incorrect number of parameters to set")
 	}
 	if p[0].Name != "K" {
 		panic("weibull: " + panicNameMismatch)


### PR DESCRIPTION
In the move from dist to distuv, many error messages were not fixed. This fixes the error messages to agree on the distuv: prefix and has them use the same panic string. Additionally, this improves the testing of continuous distributions to make sure PDF agrees with Quantile and Rand