### PR TITLE
ROC: Alternate Signature

### DIFF
--- a/roc.go
+++ b/roc.go
@@ -29,7 +29,7 @@ import (
 // If cutoffs is nil or empty all possible cutoffs are calculated,
 // resulting in fpr and tpr having length one greater than the number of
 // unique values in y. Otherwise fpr and tpr will be returned with the
-// same length as cutoffs. floats.Span can be used to generate equally 
+// same length as cutoffs. floats.Span can be used to generate equally
 // spaced cutoffs.
 //
 // More details about ROC curves are available at
@@ -53,9 +53,9 @@ func ROC(cutoffs, y []float64, classes []bool, weights []float64) (tpr, fpr []fl
 	var bin int
 	if len(cutoffs) == 0 {
 		if cutoffs == nil || cap(cutoffs) < len(y)+1 {
-		    cutoffs = make([]float64, len(y)+1)
+			cutoffs = make([]float64, len(y)+1)
 		} else {
-		    cutoffs = cutoffs[:len(y)+1]
+			cutoffs = cutoffs[:len(y)+1]
 		}
 		cutoffs[0] = math.Nextafter(y[0], y[0]-1)
 		// Choose all possible cutoffs but remove duplicate values
@@ -66,7 +66,7 @@ func ROC(cutoffs, y []float64, classes []bool, weights []float64) (tpr, fpr []fl
 			}
 			cutoffs[bin+1] = u
 		}
-		cutoffs = cutoffs[0:bin + 2]
+		cutoffs = cutoffs[0 : bin+2]
 	}
 
 	tpr = make([]float64, len(cutoffs))
@@ -77,7 +77,7 @@ func ROC(cutoffs, y []float64, classes []bool, weights []float64) (tpr, fpr []fl
 		// Update the bin until it matches the next y value
 		// skipping empty bins.
 		for bin < len(cutoffs) && y[i] > cutoffs[bin] {
-			if bin == len(cutoffs) - 1 {
+			if bin == len(cutoffs)-1 {
 				break
 			}
 			bin++
@@ -108,4 +108,3 @@ func ROC(cutoffs, y []float64, classes []bool, weights []float64) (tpr, fpr []fl
 
 	return tpr, fpr
 }
-

--- a/roc.go
+++ b/roc.go
@@ -4,36 +4,37 @@
 
 package stat
 
-import "sort"
+import (
+	"math"
+	"sort"
+)
 
 // ROC returns paired false positive rate (FPR) and true positive rate
-// (TPR) values corresponding to n cutoffs spanning the relative
-// (or receiver) operator characteristic (ROC) curve obtained when y is
+// (TPR) values corresponding to cutoffs, i.e. particular points on the
+// receiver operator characteristic (ROC) curve obtained when y is
 // treated as a binary classifier for classes with weights.
 //
-// Cutoffs are equally spaced from eps less than the minimum value of y
-// to the maximum value of y, including both endpoints meaning that the
-// resulting ROC curve will always begin at (0,0) and end at (1,1).
-//
-// The input y must be sorted, and SortWeightedLabeled can be used in
-// order to sort y together with classes and weights.
+// The input y and cutoffs must be sorted, and values in y must correspond
+// to values in classes and weights. SortWeightedLabeled can be used to
+// sort y together with classes and weights.
 //
 // For a given cutoff value, observations corresponding to entries in y
 // greater than the cutoff value are classified as false, while those
-// below (or equal to) the cutoff value are classified as true. These
+// less than (or equal to) the cutoff value are classified as true. These
 // assigned class labels are compared with the true values in the classes
 // slice and used to calculate the FPR and TPR.
 //
 // If weights is nil, all weights are treated as 1.
 //
-// When n is zero all possible cutoffs are calculated, resulting
-// in fpr and tpr having length one greater than the number of unique
-// values in y. When n is greater than one fpr and tpr will be returned
-// with length n. ROC will panic if n is equal to one or less than 0.
+// If cutoffs is nil or empty all possible cutoffs are calculated,
+// resulting in fpr and tpr having length one greater than the number of
+// unique values in y. Otherwise fpr and tpr will be returned with the
+// same length as cutoffs. EquallySpaced can be used to generate
+// equally spaced cutoffs.
 //
 // More details about ROC curves are available at
 // https://en.wikipedia.org/wiki/Receiver_operating_characteristic
-func ROC(n int, y []float64, classes []bool, weights []float64) (tpr, fpr []float64) {
+func ROC(cutoffs, y []float64, classes []bool, weights []float64) (tpr, fpr []float64) {
 	if len(y) != len(classes) {
 		panic("stat: slice length mismatch")
 	}
@@ -43,35 +44,42 @@ func ROC(n int, y []float64, classes []bool, weights []float64) (tpr, fpr []floa
 	if !sort.Float64sAreSorted(y) {
 		panic("stat: input must be sorted")
 	}
-
-	var incWidth, tol float64
-	if n == 0 {
-		if len(y) == 0 {
-			return nil, nil
+	if !sort.Float64sAreSorted(cutoffs) {
+		panic("stat: input must be sorted")
+	}
+	if len(y) == 0 {
+		return nil, nil
+	}
+	var bin int
+	if len(cutoffs) == 0 {
+		cutoffs = make([]float64, len(y)+1)
+		cutoffs[0] = math.Nextafter(y[0], y[0]-1)
+		// Choose all possible cutoffs but remove duplicate values
+		// in y.
+		for i, u := range y {
+			if i != 0 && u != y[i-1] {
+				bin++
+			}
+			cutoffs[bin+1] = u
 		}
-		tpr = make([]float64, len(y)+1)
-		fpr = make([]float64, len(y)+1)
-	} else {
-		if n < 2 {
-			panic("stat: cannot calculate fewer than 2 points on a ROC curve")
-		}
-		if len(y) == 0 {
-			return nil, nil
-		}
-		tpr = make([]float64, n)
-		fpr = make([]float64, n)
-		incWidth = (y[len(y)-1] - y[0]) / float64(n-1)
-		tol = y[0] + incWidth
-		if incWidth == 0 {
-			tpr[n-1] = 1
-			fpr[n-1] = 1
-			return
-		}
+		cutoffs = cutoffs[0:(bin + 2)]
 	}
 
-	var bin int = 1 // the initial bin is known to have 0 fpr and 0 tpr
+	tpr = make([]float64, len(cutoffs))
+	fpr = make([]float64, len(cutoffs))
+	bin = 0
 	var nPos, nNeg float64
 	for i, u := range classes {
+		// Update the bin until it matches the next y value
+		// (skip empty bins).
+		for (bin < len(cutoffs)) && (y[i] > cutoffs[bin]) {
+			if bin == (len(cutoffs) - 1) {
+				break
+			}
+			bin++
+			tpr[bin] = tpr[bin-1]
+			fpr[bin] = fpr[bin-1]
+		}
 		var posWeight, negWeight float64 = 0, 1
 		if weights != nil {
 			negWeight = weights[i]
@@ -81,31 +89,10 @@ func ROC(n int, y []float64, classes []bool, weights []float64) (tpr, fpr []floa
 		}
 		nPos += posWeight
 		nNeg += negWeight
-		tpr[bin] += posWeight
-		fpr[bin] += negWeight
-
-		// Assess if the bin needs to be updated. If n is zero,
-		// the bin is always updated, unless consecutive y values
-		// are equal. Otherwise, the bin must be updated until it
-		// matches the next y value (skipping empty bins).
-		if n == 0 {
-			if i != (len(y)-1) && y[i] != y[i+1] {
-				bin++
-				tpr[bin] = tpr[bin-1]
-				fpr[bin] = fpr[bin-1]
-			}
-		} else {
-			for i != (len(y)-1) && y[i+1] > tol {
-				tol += incWidth
-				bin++
-				tpr[bin] = tpr[bin-1]
-				fpr[bin] = fpr[bin-1]
-			}
+		if y[i] <= cutoffs[bin] {
+			tpr[bin] += posWeight
+			fpr[bin] += negWeight
 		}
-	}
-	if n == 0 {
-		tpr = tpr[:(bin + 1)]
-		fpr = fpr[:(bin + 1)]
 	}
 
 	invNeg := 1 / nNeg
@@ -114,8 +101,27 @@ func ROC(n int, y []float64, classes []bool, weights []float64) (tpr, fpr []floa
 		tpr[i] *= invPos
 		fpr[i] *= invNeg
 	}
-	tpr[len(tpr)-1] = 1
-	fpr[len(fpr)-1] = 1
 
 	return tpr, fpr
+}
+
+// EquallySpaced returns n equally spaced values,
+// beggining eps less than min and ending at max. n must be
+// at least two, and min must not be greater than max.
+func EquallySpaced(min, max float64, n int) (cutoffs []float64) {
+	if max < min {
+		panic("stat: max < min")
+	}
+	if n < 2 {
+		panic("stat: n too small")
+	}
+
+	cutoffs = make([]float64, n)
+	w := (max - min) / float64(n-1)
+	for i := range cutoffs {
+		cutoffs[i] = min + w*float64(i)
+	}
+	cutoffs[0] = math.Nextafter(min, min-1)
+
+	return cutoffs
 }

--- a/roc_example_test.go
+++ b/roc_example_test.go
@@ -13,9 +13,22 @@ import (
 func ExampleROC_unweighted() {
 	y := []float64{0, 3, 5, 6, 7.5, 8}
 	classes := []bool{true, false, true, false, false, false}
+
+	tpr, fpr := stat.ROC(nil, y, classes, nil)
+	fmt.Printf("true  positive rate: %v\n", tpr)
+	fmt.Printf("false positive rate: %v\n", fpr)
+
+	// Output:
+	// true  positive rate: [0 0.5 0.5 1 1 1 1]
+	// false positive rate: [0 0 0.25 0.25 0.5 0.75 1]
+}
+
+func ExampleROC_weighted() {
+	y := []float64{0, 3, 5, 6, 7.5, 8}
+	classes := []bool{true, false, true, false, false, false}
 	weights := []float64{4, 1, 6, 3, 2, 2}
 
-	tpr, fpr := stat.ROC(0, y, classes, weights)
+	tpr, fpr := stat.ROC(nil, y, classes, weights)
 	fmt.Printf("true  positive rate: %v\n", tpr)
 	fmt.Printf("false positive rate: %v\n", fpr)
 
@@ -24,15 +37,53 @@ func ExampleROC_unweighted() {
 	// false positive rate: [0 0 0.125 0.125 0.5 0.75 1]
 }
 
-func ExampleROC_weighted() {
-	y := []float64{0, 3, 5, 6, 7.5, 8}
-	classes := []bool{true, false, true, false, false, false}
+func ExampleROC_unsorted() {
+	y := []float64{8, 7.5, 6, 5, 3, 0}
+	classes := []bool{false, false, false, true, false, true}
+	weights := []float64{2, 2, 3, 6, 1, 4}
 
-	tpr, fpr := stat.ROC(0, y, classes, nil)
+	stat.SortWeightedLabeled(y, classes, weights)
+
+	tpr, fpr := stat.ROC(nil, y, classes, weights)
 	fmt.Printf("true  positive rate: %v\n", tpr)
 	fmt.Printf("false positive rate: %v\n", fpr)
 
 	// Output:
-	// true  positive rate: [0 0.5 0.5 1 1 1 1]
-	// false positive rate: [0 0 0.25 0.25 0.5 0.75 1]
+	// true  positive rate: [0 0.4 0.4 1 1 1 1]
+	// false positive rate: [0 0 0.125 0.125 0.5 0.75 1]
+}
+
+func ExampleROC_knownCutoffs() {
+	y := []float64{8, 7.5, 6, 5, 3, 0}
+	classes := []bool{false, false, false, true, false, true}
+	weights := []float64{2, 2, 3, 6, 1, 4}
+	cutoffs := []float64{-1, 3, 4}
+
+	stat.SortWeightedLabeled(y, classes, weights)
+
+	tpr, fpr := stat.ROC(cutoffs, y, classes, weights)
+	fmt.Printf("true  positive rate: %v\n", tpr)
+	fmt.Printf("false positive rate: %v\n", fpr)
+
+	// Output:
+	// true  positive rate: [0 0.4 0.4]
+	// false positive rate: [0 0.125 0.125]
+}
+
+func ExampleROC_equallySpacedCutoffs() {
+	y := []float64{8, 7.5, 6, 5, 3, 0}
+	classes := []bool{false, false, false, true, false, true}
+	weights := []float64{2, 2, 3, 6, 1, 4}
+	n := 9
+
+	stat.SortWeightedLabeled(y, classes, weights)
+	cutoffs := stat.EquallySpaced(y[0], y[len(y)-1], n)
+
+	tpr, fpr := stat.ROC(cutoffs, y, classes, weights)
+	fmt.Printf("true  positive rate: %v\n", tpr)
+	fmt.Printf("false positive rate: %v\n", fpr)
+
+	// Output:
+	// true  positive rate: [0 0.4 0.4 0.4 0.4 1 1 1 1]
+	// false positive rate: [0 0 0 0.125 0.125 0.125 0.5 0.5 1]
 }

--- a/roc_example_test.go
+++ b/roc_example_test.go
@@ -6,7 +6,9 @@ package stat_test
 
 import (
 	"fmt"
+	"math"
 
+	"github.com/gonum/floats"
 	"github.com/gonum/stat"
 )
 
@@ -77,7 +79,8 @@ func ExampleROC_equallySpacedCutoffs() {
 	n := 9
 
 	stat.SortWeightedLabeled(y, classes, weights)
-	cutoffs := stat.EquallySpaced(y[0], y[len(y)-1], n)
+	cutoffs := make([]float64, n)
+	floats.Span(cutoffs, math.Nextafter(y[0], y[0]-1), y[len(y)-1])
 
 	tpr, fpr := stat.ROC(cutoffs, y, classes, weights)
 	fmt.Printf("true  positive rate: %v\n", tpr)

--- a/roc_test.go
+++ b/roc_test.go
@@ -16,158 +16,158 @@ func TestROC(t *testing.T) {
 		y       []float64
 		c       []bool
 		w       []float64
-		n       int
+		cutoffs []float64
 		wantTPR []float64
 		wantFPR []float64
 	}{
-		{
+		{ // 0
 			y:       []float64{0, 3, 5, 6, 7.5, 8},
 			c:       []bool{true, false, true, false, false, false},
 			wantTPR: []float64{0, 0.5, 0.5, 1, 1, 1, 1},
 			wantFPR: []float64{0, 0, 0.25, 0.25, 0.5, 0.75, 1},
 		},
-		{
+		{ // 1
 			y:       []float64{0, 3, 5, 6, 7.5, 8},
 			c:       []bool{true, false, true, false, false, false},
 			w:       []float64{4, 1, 6, 3, 2, 2},
 			wantTPR: []float64{0, 0.4, 0.4, 1, 1, 1, 1},
 			wantFPR: []float64{0, 0, 0.125, 0.125, 0.5, 0.75, 1},
 		},
-		{
+		{ // 2
 			y:       []float64{0, 3, 5, 6, 7.5, 8},
 			c:       []bool{true, false, true, false, false, false},
-			n:       int(5),
+			cutoffs: []float64{-1, 2, 4, 6, 8},
 			wantTPR: []float64{0, 0.5, 0.5, 1, 1},
 			wantFPR: []float64{0, 0, 0.25, 0.5, 1},
 		},
-		{
+		{ // 3
 			y:       []float64{0, 3, 5, 6, 7.5, 8},
 			c:       []bool{true, false, true, false, false, false},
-			n:       int(9),
+			cutoffs: []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
 			wantTPR: []float64{0, 0.5, 0.5, 0.5, 0.5, 1, 1, 1, 1},
 			wantFPR: []float64{0, 0, 0, 0.25, 0.25, 0.25, 0.5, 0.5, 1},
 		},
-		{
+		{ // 4
 			y:       []float64{0, 3, 5, 6, 7.5, 8},
 			c:       []bool{true, false, true, false, false, false},
 			w:       []float64{4, 1, 6, 3, 2, 2},
-			n:       int(5),
+			cutoffs: []float64{-1, 2, 4, 6, 8},
 			wantTPR: []float64{0, 0.4, 0.4, 1, 1},
 			wantFPR: []float64{0, 0, 0.125, 0.5, 1},
 		},
-		{
+		{ // 5
 			y:       []float64{0, 3, 5, 6, 7.5, 8},
 			c:       []bool{true, false, true, false, false, false},
 			w:       []float64{4, 1, 6, 3, 2, 2},
-			n:       int(9),
+			cutoffs: []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
 			wantTPR: []float64{0, 0.4, 0.4, 0.4, 0.4, 1, 1, 1, 1},
 			wantFPR: []float64{0, 0, 0, 0.125, 0.125, 0.125, 0.5, 0.5, 1},
 		},
-		{
+		{ // 6
 			y:       []float64{0, 3, 6, 6, 6, 8},
 			c:       []bool{true, false, true, false, false, false},
 			wantTPR: []float64{0, 0.5, 0.5, 1, 1},
 			wantFPR: []float64{0, 0, 0.25, 0.75, 1},
 		},
-		{
+		{ // 7
 			y:       []float64{0, 3, 6, 6, 6, 8},
 			c:       []bool{true, false, true, false, false, false},
 			w:       []float64{4, 1, 6, 3, 2, 2},
 			wantTPR: []float64{0, 0.4, 0.4, 1, 1},
 			wantFPR: []float64{0, 0, 0.125, 0.75, 1},
 		},
-		{
+		{ // 8
 			y:       []float64{0, 3, 6, 6, 6, 8},
 			c:       []bool{true, false, true, false, false, false},
-			n:       int(5),
+			cutoffs: []float64{-1, 2, 4, 6, 8},
 			wantTPR: []float64{0, 0.5, 0.5, 1, 1},
 			wantFPR: []float64{0, 0, 0.25, 0.75, 1},
 		},
-		{
+		{ // 9
 			y:       []float64{0, 3, 6, 6, 6, 8},
 			c:       []bool{true, false, true, false, false, false},
-			n:       int(9),
+			cutoffs: []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
 			wantTPR: []float64{0, 0.5, 0.5, 0.5, 0.5, 0.5, 1, 1, 1},
 			wantFPR: []float64{0, 0, 0, 0.25, 0.25, 0.25, 0.75, 0.75, 1},
 		},
-		{
+		{ // 10
 			y:       []float64{0, 3, 6, 6, 6, 8},
 			c:       []bool{true, false, true, false, false, false},
 			w:       []float64{4, 1, 6, 3, 2, 2},
-			n:       int(5),
+			cutoffs: []float64{-1, 2, 4, 6, 8},
 			wantTPR: []float64{0, 0.4, 0.4, 1, 1},
 			wantFPR: []float64{0, 0, 0.125, 0.75, 1},
 		},
-		{
+		{ // 11
 			y:       []float64{0, 3, 6, 6, 6, 8},
 			c:       []bool{true, false, true, false, false, false},
 			w:       []float64{4, 1, 6, 3, 2, 2},
-			n:       int(9),
+			cutoffs: []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
 			wantTPR: []float64{0, 0.4, 0.4, 0.4, 0.4, 0.4, 1, 1, 1},
 			wantFPR: []float64{0, 0, 0, 0.125, 0.125, 0.125, 0.75, 0.75, 1},
 		},
-		{
+		{ // 12
 			y:       []float64{1, 2},
 			c:       []bool{true, true},
 			wantTPR: []float64{0, 0.5, 1},
 			wantFPR: []float64{0, 0, 1},
 		},
-		{
+		{ // 13
 			y:       []float64{1, 2},
 			c:       []bool{true, true},
-			n:       int(2),
+			cutoffs: []float64{-1, 2},
 			wantTPR: []float64{0, 1},
 			wantFPR: []float64{0, 1},
 		},
-		{
+		{ // 14
 			y:       []float64{1, 2},
 			c:       []bool{true, true},
-			n:       int(7),
-			wantTPR: []float64{0, 0.5, 0.5, 0.5, 0.5, 0.5, 1},
-			wantFPR: []float64{0, 0, 0, 0, 0, 0, 1},
+			cutoffs: []float64{0, 1.2, 1.4, 1.6, 1.8, 2},
+			wantTPR: []float64{0, 0.5, 0.5, 0.5, 0.5, 1},
+			wantFPR: []float64{0, 0, 0, 0, 0, 1},
 		},
-		{
+		{ // 15
 			y:       []float64{1},
 			c:       []bool{true},
 			wantTPR: []float64{0, 1},
 			wantFPR: []float64{0, 1},
 		},
-		{
+		{ // 16
 			y:       []float64{1},
 			c:       []bool{true},
-			n:       int(2),
+			cutoffs: []float64{-1, 1},
 			wantTPR: []float64{0, 1},
 			wantFPR: []float64{0, 1},
 		},
-		{
+		{ // 17
 			y:       []float64{1},
 			c:       []bool{false},
 			wantTPR: []float64{0, 1},
 			wantFPR: []float64{0, 1},
 		},
-		{
+		{ // 18
 			y:       []float64{0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 10},
 			c:       []bool{true, false, true, true, false, false, true},
-			n:       int(5),
+			cutoffs: []float64{-1, 2.5, 5, 7.5, 10},
 			wantTPR: []float64{0, 0.75, 0.75, 0.75, 1},
 			wantFPR: []float64{0, 1, 1, 1, 1},
 		},
-		{
+		{ // 19
 			y:       []float64{},
 			c:       []bool{},
 			wantTPR: nil,
 			wantFPR: nil,
 		},
-		{
+		{ // 20
 			y:       []float64{},
 			c:       []bool{},
-			n:       int(5),
+			cutoffs: []float64{-1, 2.5, 5, 7.5, 10},
 			wantTPR: nil,
 			wantFPR: nil,
 		},
 	}
 	for i, test := range cases {
-		gotTPR, gotFPR := ROC(test.n, test.y, test.c, test.w)
+		gotTPR, gotFPR := ROC(test.cutoffs, test.y, test.c, test.w)
 		if !floats.Same(gotTPR, test.wantTPR) {
 			t.Errorf("%d: unexpected TPR got:%v want:%v", i, gotTPR, test.wantTPR)
 		}


### PR DESCRIPTION
Found some free time, so I had a go at this. 

As per #104 the new ROC function takes cutoffs as an argument instead of the number of cutoffs n, and there is a helper function EquallySpaced for generating equallly spaced cutoffs. The need for a helper function to maintain the old functionality is abit clunky but this allows for particular cutoffs of interest to be defined which wasn't the case before, and I think the code is (slightly) easier to read.

PTAL @kortschak @sbinet :)
