### PR TITLE
stat: package description

### DIFF
--- a/stat.go
+++ b/stat.go
@@ -3,6 +3,8 @@
 // license that can be found in the LICENSE file.
 
 // Package stat provides generalized statistical functions.
+// Functions that take a data matrix argument assume that rows correspond to observations
+// and columns to variables.
 package stat
 
 import (


### PR DESCRIPTION
So I was reading the `CovarianceMatrix` function and saw it used `SymOuterK` which in the description says it calculates `s = alpha * x * x'`, which confused me until I saw that it was operating on the transpose of the input. This made me realise that there should be a package-wide convention for how data matrices are treated. This is explicitly included in the comment for `PrincipalComponents` but it seemed reasonable to me that it should just be made a blanket statement to force everything to be consistent. 

We are currently using the more popular convention -- rows as observations -- which is the same as base R uses, but it is not uncommon, particularly in multivariate high-dimensional statistics, to use the other convention -- columns as observations. So I thought it was important to be clear which convention we are using moving forward.

@kortschak @btracey @jonlawlor what do you think?
