### PR TITLE
stat: make CCA and PCA analysis reuse allocations

### DIFF
--- a/cca_example_test.go
+++ b/cca_example_test.go
@@ -78,17 +78,18 @@ func ExampleCanonicalCorrelations() {
 	fmt.Printf("corRaw = %.4f", mat64.Formatted(corRaw, mat64.Prefix("         ")))
 
 	// Calculate the canonical correlations.
-	cc, err := stat.CanonicalCorrelations(xdata, ydata, nil)
+	var cc stat.CC
+	err := cc.CanonicalCorrelations(xdata, ydata, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Unpack cc.
 	ccors := cc.Corrs(nil)
-	pVecs := cc.Left(true)
-	qVecs := cc.Right(true)
-	phiVs := cc.Left(false)
-	psiVs := cc.Right(false)
+	pVecs := cc.Left(nil, true)
+	qVecs := cc.Right(nil, true)
+	phiVs := cc.Left(nil, false)
+	psiVs := cc.Right(nil, false)
 
 	// Canonical Correlation Matrix, or the correlations between the sphered
 	// data.

--- a/cca_test.go
+++ b/cca_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestCanonicalCorrelations(t *testing.T) {
+tests:
 	for i, test := range []struct {
 		xdata     mat64.Matrix
 		ydata     mat64.Matrix
@@ -148,36 +149,43 @@ func TestCanonicalCorrelations(t *testing.T) {
 			epsilon: 1e-12,
 		},
 	} {
-		cc, err := stat.CanonicalCorrelations(test.xdata, test.ydata, test.weights)
-		if err != nil {
-			t.Errorf("%d: unexpected error: %v", i, err)
-			continue
-		}
+		var cc stat.CC
+		var corrs []float64
+		var pVecs, qVecs *mat64.Dense
+		var phiVs, psiVs *mat64.Dense
+		for j := 0; j < 2; j++ {
+			err := cc.CanonicalCorrelations(test.xdata, test.ydata, test.weights)
+			if err != nil {
+				t.Errorf("%d use %d: unexpected error: %v", i, j, err)
+				continue tests
+			}
 
-		corrs := cc.Corrs(nil)
-		pVecs := cc.Left(true)
-		qVecs := cc.Right(true)
-		phiVs := cc.Left(false)
-		psiVs := cc.Right(false)
+			corrs = cc.Corrs(corrs)
+			pVecs = cc.Left(pVecs, true)
+			qVecs = cc.Right(qVecs, true)
+			phiVs = cc.Left(phiVs, false)
+			psiVs = cc.Right(psiVs, false)
 
-		if !floats.EqualApprox(corrs, test.wantCorrs, test.epsilon) {
-			t.Errorf("%d: unexpected variance result got:%v, want:%v", i, corrs, test.wantCorrs)
-		}
-		if !mat64.EqualApprox(pVecs, test.wantpVecs, test.epsilon) {
-			t.Errorf("%d: unexpected CCA result got:\n%v\nwant:\n%v",
-				i, mat64.Formatted(pVecs), mat64.Formatted(test.wantpVecs))
-		}
-		if !mat64.EqualApprox(qVecs, test.wantqVecs, test.epsilon) {
-			t.Errorf("%d: unexpected CCA result got:\n%v\nwant:\n%v",
-				i, mat64.Formatted(qVecs), mat64.Formatted(test.wantqVecs))
-		}
-		if !mat64.EqualApprox(phiVs, test.wantphiVs, test.epsilon) {
-			t.Errorf("%d: unexpected CCA result got:\n%v\nwant:\n%v",
-				i, mat64.Formatted(phiVs), mat64.Formatted(test.wantphiVs))
-		}
-		if !mat64.EqualApprox(psiVs, test.wantpsiVs, test.epsilon) {
-			t.Errorf("%d: unexpected CCA result got:\n%v\nwant:\n%v",
-				i, mat64.Formatted(psiVs), mat64.Formatted(test.wantpsiVs))
+			if !floats.EqualApprox(corrs, test.wantCorrs, test.epsilon) {
+				t.Errorf("%d use %d: unexpected variance result got:%v, want:%v",
+					i, j, corrs, test.wantCorrs)
+			}
+			if !mat64.EqualApprox(pVecs, test.wantpVecs, test.epsilon) {
+				t.Errorf("%d use %d: unexpected CCA result got:\n%v\nwant:\n%v",
+					i, j, mat64.Formatted(pVecs), mat64.Formatted(test.wantpVecs))
+			}
+			if !mat64.EqualApprox(qVecs, test.wantqVecs, test.epsilon) {
+				t.Errorf("%d use %d: unexpected CCA result got:\n%v\nwant:\n%v",
+					i, j, mat64.Formatted(qVecs), mat64.Formatted(test.wantqVecs))
+			}
+			if !mat64.EqualApprox(phiVs, test.wantphiVs, test.epsilon) {
+				t.Errorf("%d use %d: unexpected CCA result got:\n%v\nwant:\n%v",
+					i, j, mat64.Formatted(phiVs), mat64.Formatted(test.wantphiVs))
+			}
+			if !mat64.EqualApprox(psiVs, test.wantpsiVs, test.epsilon) {
+				t.Errorf("%d use %d: unexpected CCA result got:\n%v\nwant:\n%v",
+					i, j, mat64.Formatted(psiVs), mat64.Formatted(test.wantpsiVs))
+			}
 		}
 	}
 }

--- a/pca_example_test.go
+++ b/pca_example_test.go
@@ -30,16 +30,17 @@ func ExamplePrincipalComponents() {
 
 	// Calculate the principal component direction vectors
 	// and variances.
-	vecs, vars, ok := stat.PrincipalComponents(iris, nil)
+	var pc stat.PC
+	ok := pc.PrincipalComponents(iris, nil)
 	if !ok {
 		return
 	}
-	fmt.Printf("variances = %.4f\n\n", vars)
+	fmt.Printf("variances = %.4f\n\n", pc.Vars(nil))
 
 	// Project the data onto the first 2 principal components.
 	k := 2
 	var proj mat64.Dense
-	proj.Mul(iris, vecs.View(0, 0, d, k))
+	proj.Mul(iris, pc.Vectors(nil).Slice(0, d, 0, k))
 
 	fmt.Printf("proj = %.4f", mat64.Formatted(&proj, mat64.Prefix("       ")))
 


### PR DESCRIPTION
@btracey Please take a look.

This is a stab at a PCA API for allocation reuse. I will add CCA to this if you think this is the right way to go (and flesh out the tests and fix up docs).

One issue is the size restrictions on the input matrix for Vectors. It is not easy to be strict without being difficult because of the behaviour of mat64.SVD.