### PR TITLE
Remove race in checking for sigma

### DIFF
--- a/distmv/normal.go
+++ b/distmv/normal.go
@@ -217,14 +217,10 @@ func (n *Normal) MarginalNormal(vars []int, src *rand.Rand) (*Normal, bool) {
 // The input src is passed to the constructed distuv.Normal.
 func (n *Normal) MarginalNormalSingle(i int, src *rand.Rand) distuv.Normal {
 	var std float64
-	if n.sigma != nil {
-		std = n.sigma.At(i, i)
-	} else {
-		// Reconstruct the {i,i} diagonal element of the covariance directly.
-		for j := 0; j <= i; j++ {
-			v := n.lower.At(i, j)
-			std += v * v
-		}
+	// Construct the {i,i} diagonal element of the covariance directly.
+	for j := 0; j <= i; j++ {
+		v := n.lower.At(i, j)
+		std += v * v
 	}
 	return distuv.Normal{
 		Mu:     n.mu[i],

--- a/distmv/studentst.go
+++ b/distmv/studentst.go
@@ -301,14 +301,10 @@ func (s *StudentsT) MarginalStudentsT(vars []int, src *rand.Rand) (dist *Student
 // The input src is passed to the call to NewStudentsT.
 func (s *StudentsT) MarginalStudentsTSingle(i int, src *rand.Rand) distuv.StudentsT {
 	var std float64
-	if s.sigma != nil {
-		std = s.sigma.At(i, i)
-	} else {
-		// Reconstruct the {i,i} diagonal element of the covariance directly.
-		for j := 0; j <= i; j++ {
-			v := s.lower.At(i, j)
-			std += v * v
-		}
+	// Construct the {i,i} diagonal element of the covariance directly.
+	for j := 0; j <= i; j++ {
+		v := s.lower.At(i, j)
+		std += v * v
 	}
 
 	return distuv.StudentsT{


### PR DESCRIPTION
Methods in Normal and StudentsT should either use sigma or not, they shouldn't conditionally use sigma depending on if it has been set. The current code races with setSigma(). Fixing it with a mutex is not strictly a data race, but it does mean the behavior of the program depends on execution order. Remove this behavior entirely by just computing the relevant entry of the covariance matrix.