### PR TITLE
Store sigma in Normal and StudentsT

### DIFF
--- a/distmv/normal_test.go
+++ b/distmv/normal_test.go
@@ -489,8 +489,6 @@ func TestMarginalSingle(t *testing.T) {
 		if !ok {
 			t.Fatalf("Bad test, covariance matrix not positive definite")
 		}
-		// Verify with nil Sigma.
-		normal.sigma = nil
 		for i, mean := range test.mu {
 			norm := normal.MarginalNormalSingle(i, nil)
 			if norm.Mean() != mean {
@@ -499,19 +497,6 @@ func TestMarginalSingle(t *testing.T) {
 			std := math.Sqrt(test.sigma.At(i, i))
 			if math.Abs(norm.StdDev()-std) > 1e-14 {
 				t.Errorf("StdDev mismatch nil Sigma, idx %v: want %v, got %v.", i, std, norm.StdDev())
-			}
-		}
-
-		// Verify with non-nil Sigma.
-		normal.setSigma()
-		for i, mean := range test.mu {
-			norm := normal.MarginalNormalSingle(i, nil)
-			if norm.Mean() != mean {
-				t.Errorf("Mean mismatch non-nil Sigma, idx %v: want %v, got %v.", i, mean, norm.Mean())
-			}
-			std := math.Sqrt(test.sigma.At(i, i))
-			if math.Abs(norm.StdDev()-std) > 1e-14 {
-				t.Errorf("StdDev mismatch non-nil Sigma, idx %v: want %v, got %v.", i, std, norm.StdDev())
 			}
 		}
 	}

--- a/distmv/normalbench_test.go
+++ b/distmv/normalbench_test.go
@@ -7,7 +7,6 @@ package distmv
 import (
 	"log"
 	"math/rand"
-	"sync"
 	"testing"
 
 	"github.com/gonum/matrix/mat64"
@@ -38,8 +37,6 @@ func BenchmarkMarginalNormalReset10(b *testing.B) {
 		if !ok {
 			b.Error("bad test")
 		}
-		normal.sigma = nil
-		normal.once = sync.Once{}
 		_ = marg
 	}
 }

--- a/distmv/studentst_test.go
+++ b/distmv/studentst_test.go
@@ -182,12 +182,9 @@ func TestStudentsTConditional(t *testing.T) {
 			muOb[i] = test.mean[v]
 		}
 
-		s.setSigma()
-		sUp.setSigma()
-
 		var sig11, sig22 mat64.SymDense
-		sig11.SubsetSym(s.sigma, unob)
-		sig22.SubsetSym(s.sigma, ob)
+		sig11.SubsetSym(&s.sigma, unob)
+		sig22.SubsetSym(&s.sigma, ob)
 
 		sig12 := mat64.NewDense(len(unob), len(ob), nil)
 		for i := range unob {
@@ -221,7 +218,7 @@ func TestStudentsTConditional(t *testing.T) {
 
 		dot := mat64.Dot(shiftVec, &tmp)
 		tmp3.Scale((test.nu+dot)/(test.nu+float64(len(ob))), &tmp3)
-		if !mat64.EqualApprox(&tmp3, sUp.sigma, 1e-10) {
+		if !mat64.EqualApprox(&tmp3, &sUp.sigma, 1e-10) {
 			t.Errorf("Sigma mismatch")
 		}
 	}
@@ -248,8 +245,6 @@ func TestStudentsTMarginalSingle(t *testing.T) {
 		if !ok {
 			t.Fatalf("Bad test, covariance matrix not positive definite")
 		}
-		// Verify with nil Sigma.
-		studentst.sigma = nil
 		for i, mean := range test.mu {
 			st := studentst.MarginalStudentsTSingle(i, nil)
 			if st.Mean() != mean {
@@ -261,19 +256,6 @@ func TestStudentsTMarginalSingle(t *testing.T) {
 			}
 			if st.Nu != test.nu {
 				t.Errorf("Nu mismatch nil Sigma, idx %v: want %v, got %v ", i, test.nu, st.Nu)
-			}
-		}
-
-		// Verify with non-nil Sigma.
-		studentst.setSigma()
-		for i, mean := range test.mu {
-			st := studentst.MarginalStudentsTSingle(i, nil)
-			if st.Mean() != mean {
-				t.Errorf("Mean mismatch non-nil Sigma, idx %v: want %v, got %v.", i, mean, st.Mean())
-			}
-			std := math.Sqrt(test.sigma.At(i, i))
-			if math.Abs(st.Sigma-std) > 1e-14 {
-				t.Errorf("StdDev mismatch non-nil Sigma, idx %v: want %v, got %v.", i, std, st.StdDev())
 			}
 		}
 	}


### PR DESCRIPTION
Currently, we throw sigma away, and recompute it if necessary. This PR keeps sigma. This fixes an issue with concurrent calling of methods. In addition, however, it removes any possible issues with reconstructing a badly-conditioned sigma from its Cholesky decomposition, and avoids an extra n^3 work if sigma does need to be recomputed. The complexity of the implementation and difficulties listed above is not worth the memory savings in some cases, especially since the memory of the type is already O(n^2)