### PR TITLE
stat: use the updated decomposition extraction API

### DIFF
--- a/cca_example_test.go
+++ b/cca_example_test.go
@@ -85,11 +85,11 @@ func ExampleCC() {
 	}
 
 	// Unpack cc.
-	ccors := cc.Corrs(nil)
-	pVecs := cc.Left(nil, true)
-	qVecs := cc.Right(nil, true)
-	phiVs := cc.Left(nil, false)
-	psiVs := cc.Right(nil, false)
+	ccors := cc.CorrsTo(nil)
+	pVecs := cc.LeftTo(nil, true)
+	qVecs := cc.RightTo(nil, true)
+	phiVs := cc.LeftTo(nil, false)
+	psiVs := cc.RightTo(nil, false)
 
 	// Canonical Correlation Matrix, or the correlations between the sphered
 	// data.

--- a/cca_test.go
+++ b/cca_test.go
@@ -160,11 +160,11 @@ tests:
 				continue tests
 			}
 
-			corrs = cc.Corrs(corrs)
-			pVecs = cc.Left(pVecs, true)
-			qVecs = cc.Right(qVecs, true)
-			phiVs = cc.Left(phiVs, false)
-			psiVs = cc.Right(psiVs, false)
+			corrs = cc.CorrsTo(corrs)
+			pVecs = cc.LeftTo(pVecs, true)
+			qVecs = cc.RightTo(qVecs, true)
+			phiVs = cc.LeftTo(phiVs, false)
+			psiVs = cc.RightTo(psiVs, false)
 
 			if !floats.EqualApprox(corrs, test.wantCorrs, test.epsilon) {
 				t.Errorf("%d use %d: unexpected variance result got:%v, want:%v",

--- a/pca_example_test.go
+++ b/pca_example_test.go
@@ -35,12 +35,12 @@ func ExamplePrincipalComponents() {
 	if !ok {
 		return
 	}
-	fmt.Printf("variances = %.4f\n\n", pc.Vars(nil))
+	fmt.Printf("variances = %.4f\n\n", pc.VarsTo(nil))
 
 	// Project the data onto the first 2 principal components.
 	k := 2
 	var proj mat64.Dense
-	proj.Mul(iris, pc.Vectors(nil).Slice(0, d, 0, k))
+	proj.Mul(iris, pc.VectorsTo(nil).Slice(0, d, 0, k))
 
 	fmt.Printf("proj = %.4f", mat64.Formatted(&proj, mat64.Prefix("       ")))
 

--- a/pca_test.go
+++ b/pca_test.go
@@ -152,8 +152,8 @@ tests:
 		var vars []float64
 		for j := 0; j < 2; j++ {
 			ok := pc.PrincipalComponents(test.data, test.weights)
-			vecs = pc.Vectors(vecs)
-			vars = pc.Vars(vars)
+			vecs = pc.VectorsTo(vecs)
+			vars = pc.VarsTo(vars)
 			if !ok {
 				t.Errorf("unexpected SVD failure for test %d use %d", i, j)
 				continue tests


### PR DESCRIPTION
I have left the CC methods `Left` and `Right` as they are rather than renaming to `LeftTo` and `RightTo`, which they probably should be changed to.

@btracey @vladimir-ch Please take a look.

Depends on https://github.com/gonum/matrix/pull/436.